### PR TITLE
fix: `exit 1` properly exits

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -50,7 +50,7 @@ racket_install() {
 
         echo "Installed Racket ${release}"
 
-    ) || (rm -rf $install_path; exit 1)
+    ) || {rm -rf $install_path; exit 1; }
 }
 
 racket_install $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
In this case, there is no difference because the the script currently exists with the exit code of the subshell - 1.

But later, code may be added - in which case, the `exit 1` has no effect (because it is in a subshell). And `set -e` isn't set for the script as a whole.