### PR TITLE
Fix incomplete installations

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -38,7 +38,7 @@ racket_install() {
     curl -L "$(racket_pkg "$release")" >r"acket-${release}.tgz"
     tar -xf "racket-${release}.tgz"
     cd "racket-${release}/src/"
-    ./configure "${ASDF_RACKET_CONFIG_FLAGS}"
+    xargs ./configure <<<"${ASDF_RACKET_CONFIG_FLAGS}"
     make
     make install
 


### PR DESCRIPTION
If applied, this commit will use `xargs` to pass `./configure`
arguments.

Prior to this change, `asdf install racket $version` doesn't work
properly because of an error in configure step, even if it ends with a
success message.

Fix #10
